### PR TITLE
Fix typo on about page

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -38,8 +38,8 @@ We've put together a little checklist, of things to keep in mind when hosting a 
 * Have your presentation setup ready and tested in advance
    * Projector
    * VGA cable
-   * VGA  ⟺ Mini DisplayPort (<http://store.apple.com/dk/product/MB572Z/A>)
-   * VGA  ⟺ Mini DVI (<http://store.apple.com/dk/product/M9320G/A>)
+   * VGA ⟺ Mini DisplayPort (<http://store.apple.com/dk/product/MB572Z/A>)
+   * VGA ⟺ Mini DVI (<http://store.apple.com/dk/product/M9320G/A>)
    * Power outlet for speaker's laptop, bonus points for outlets for participants
    * Possibly power supply for laptops, Macs are popular
 * Drinks, snacks


### PR DESCRIPTION
I also removed some double whitespaces which weren't needed, just so the pull request wouldn't only contain the removal of one character.
