### PR TITLE
Adding menu background for readability

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -139,6 +139,7 @@ header .navigation li {
 
 header .navigation li a {
 	color: #fff;
+	background: rgba(0,0,0,0.4);
 }
 
 header h3 {


### PR DESCRIPTION
Added a vague background to the menu items. It will help the white text stand out.

Before:
![screen shot 2013-11-29 at 10 07 49](https://f.cloud.github.com/assets/465996/1643890/2ba40936-58d6-11e3-8c86-b0a972d821b2.png)

After:
![screen shot 2013-11-29 at 10 08 13](https://f.cloud.github.com/assets/465996/1643894/35f7056e-58d6-11e3-9a0b-0bfed13b6f30.png)
