### PR TITLE
Auto generate lanyrd event info based on lanyrd event link in individual post variable

### DIFF
--- a/_includes/lanyrd.html
+++ b/_includes/lanyrd.html
@@ -1,0 +1,28 @@
+{% if page.lanyrd %}
+<section class="lanyrd">
+    <h2>Schedule</h2>
+
+    <div class="lanyrd-target-schedule">
+        <a href="{{ page.lanyrd }}/schedule/"
+            class="lanyrd-schedule"
+            data-lanyrd-abstracts
+            data-lanyrd-truncateabstracts="50"
+            data-lanyrd-speakers
+            data-lanyrd-speakerlabels>
+            Schedule for {{ page.title }} on Lanyrd
+        </a>
+    </div>
+
+    <h2>Attendees</h2>
+
+    Please visit the <a href="{{ page.lanyrd }}">Lanyrd page</a> and let us know if you're attending. It greatly helps us coordinate with the venue to set out chairs, drinks, etc.
+
+    <div class="lanyrd-target-participants">
+        <a href="{{ page.lanyrd }}/attendees/"
+            class="lanyrd-participants"
+            data-lanyrd-limit="200">
+            Attendee list for {{ page.title }} on Lanyrd
+        </a>
+    </div>
+</section>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,3 +7,4 @@ layout: single
  {{ content }}
 </div>
 
+{% include lanyrd.html %}

--- a/_posts/2013-11-28-december-meetup.md
+++ b/_posts/2013-11-28-december-meetup.md
@@ -3,33 +3,9 @@ title: December 19th - CopenhagenJS December 2013 meetup
 layout: post
 author: Kenneth Auchenberg
 date: Thursday, December 19, 19:00
+lanyrd: http://lanyrd.com/2013/copenhagenjs-december
 ---
 
 The CopenhagenJS December 2013 meetup will be hosted by [TBD](#).
 
 We got 1 speaker for the event, but as always if you have a project you would like us to know about, some obscure problem you have solved in an interesting way, or just want to do a lightning talk to inspire some discussion, then let us know.
-
-### Event schedule
-
-<div class="lanyrd-target-schedule">
-    <a href="http://lanyrd.com/2013/copenhagenjs-december/schedule/"
-        class="lanyrd-schedule"
-        data-lanyrd-abstracts
-        data-lanyrd-truncateabstracts="50"
-        data-lanyrd-speakers
-        data-lanyrd-speakerlabels>
-        Schedule for CopenhagenJS — December 2013 on Lanyrd
-    </a>
-</div>
-
-### Event attendees
-
-Please visit the [Lanyrd page](http://lanyrd.com/2013/copenhagenjs-december/) and let us know if you're attending. It greatly helps us coordinate with the venue to set out chairs, drinks, etc.
-
-<div class="lanyrd-target-participants">
-    <a href="http://lanyrd.com/2013/copenhagenjs-december/attendees/"
-        class="lanyrd-participants"
-        data-lanyrd-limit="30">
-        Attendee list for CopenhagenJS — December 2013 on Lanyrd
-    </a>
-</div>

--- a/index.html
+++ b/index.html
@@ -28,16 +28,24 @@ title: CopenhagenJS
 <section class="container">
   <div class="next-meetup">
     <h2 class="text-center">Our next meetup will take place at</h2>
-    {% for post in site.posts limit:1 %}
+    {% for page in site.posts limit:1 %}
+      {% if page.date %}
       <header>
-        {{ post.date | date: "%A, %B %d, %H:%M" }}
+        {% if page.lanyrd %}
+          <a href="{{ post.lanyrd }}">{{ page.date | date: "%A, %B %d, %H:%M" }}</a>
+        {% else %}
+          {{ page.date | date: "%A, %B %d, %H:%M" }}
+        {% endif %}
       </header>
+      {% endif %}
 
       <div class="post">
-      	<div class="post_content">
-      	  {{ post.content }}
-      	</div>
+        <div class="post_content">
+          {{ page.content }}
+        </div>
       </div>
+
+      {% include lanyrd.html %}
     {% endfor %}
   </div>
 </section>


### PR DESCRIPTION
Heads up!

This update should simplify creation of new event posts. I have centralized lanyrd event information into the `lanyrd` variable on each post and am now auto generating the always present lanyrd widgets based on that. Take a look at the updated december 2013 event post to see the new convention.

@copenhagenjs/owners 
