### PR TITLE
set time

### DIFF
--- a/_posts/2014-09-06-september-lund-meetup.md
+++ b/_posts/2014-09-06-september-lund-meetup.md
@@ -2,7 +2,7 @@
 title: September 18th – Yes, CopenhagenJS, but in Lund
 layout: post
 author: Björn Söderqvist
-date: Saturday, September 18, 2014 16:00
+date: Saturday, September 18, 2014 17:30
 lanyrd: http://lanyrd.com/2014/copenhagenjs-september-2013-in-lund
 ---
 
@@ -16,7 +16,7 @@ The theme of this meetup is: Show us something you've worked on, or a tool you l
 
 Ideas, discussions, learnings, hacks and demoes are most welcome. No big slide decks are needed, just get up there and tell us what's on your mind.
 
-
+The venue opens at 17:30 for food and drinks, the first talk starts at 18:30.
 
 ---
 


### PR DESCRIPTION
There was a time mistake. We had set the time to 19.00 and the venue to 17.30. 

I've agreed with the venue to start at 17.30 with the foods and drinks, and talk at 18.30.
