### PR TITLE
Disabled all the rules violated by the Markdown posts files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,19 @@
 {
   "default": true,
-  "commands-show-output": false
+  "commands-show-output": false,
+  "heading-increment": false,
+  "no-bare-urls": false,
+  "line-length": false,
+  "blanks-around-headings": false,
+  "no-trailing-punctuation": false,
+  "no-multiple-blanks": false,
+  "no-inline-html": false,
+  "single-title": false,
+  "no-hard-tabs": false,
+  "no-trailing-spaces": false,
+  "no-missing-space-atx": false,
+  "single-trailing-newline": false,
+  "no-emphasis-as-heading": false,
+  "heading-style": false,
+  "no-blanks-blockquote": false
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ jobs:
     - stage: "Documentation test"
       name: "markdownlint test"
       script: markdownlint README.md
+    - stage: "Content test"
+      name: "markdownlint test"
+      script: markdownlint _posts/*.md
     - stage: "Build and test"
       name: "npm build and test"
       script: npm run build && npm test


### PR DESCRIPTION
Hi @kevinsimper 

I have added a job more in the Travis CI config doing a Markdownlint check of the contents, namely the files in `_posts`.

Currently I have disabled the following Markdownlint rules, so it does not break the build.

- `heading-increment` ([MD001](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md001))
- `no-bare-urls` ([MD034](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md034))
- `line-length` ([MD013](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013))
- `blanks-around-headings` ([MD022](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md02))
- `no-trailing-punctuation` ([MD026](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025))
- `no-multiple-blanks` ([MD012](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md012))
- `no-inline-html` ([MD033](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md033))
- `single-title` ([MD025](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025))
- `no-hard-tabs` ([MD010](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md010))
- `no-trailing-spaces` ([MD009](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009))
- `no-missing-space-atx` ([MD018](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md018))
- `single-trailing-newline` ([MD047](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047))
- `no-emphasis-as-heading` ([MD036](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md036))
- `heading-style` ([MD003](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md003))
- `no-blanks-blockquote` ([MD028](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md028))

 I will address each of these in separate PRs and I will find out where and if [Editor Config](https://editorconfig.org/) or [Prettier](https://prettier.io/) as I commented in issue #192. Rules like `no-hard-tabs` can and should be handled by other tools. And perhaps rules like `no-bare-urls` should remain disabled since we decide it makes more sense.

I will be cautious of changes which change layout or communication value and I will point these out. I just got my local instance working as I wanted (please see question #194). 

Please let me know what you thinks before I start producing PRs, yes it is [Hacktoberfest](https://hacktoberfest.digitalocean.com/) month