### PR TITLE
Don't copy posts into static folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ node_modules
 .next
 out
 pages/archive
-static/posts
-static/speakers.json
 .firebase
 bazel-bin
 bazel-copenhagenjs.dk

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "npm run process && next",
     "fix-lint": "npx prettier --write --single-quote --no-semi next.config.js 'components/**/*.js' 'pages/*.js' '_posts/*.json' 'utils/*.js' 'data/*.js' 'stories/*.js' '.storybook/*.js'",
     "lint": "npx prettier -l --single-quote --no-semi next.config.js 'components/**/*.js' 'pages/*.js' '_posts/*.json' 'utils/*.js' 'data/*.js' 'stories/*.js' '.storybook/*.js'",
-    "process": "npm run process-archive && cp -R _posts/ static/posts",
+    "process": "npm run process-archive",
     "process-archive": "npx mkdirp pages/archive && node utils/processmd",
     "start": "next start",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
We used it to fetch the markdown to show it on the frontpage. That is not needed anymore as we use GraphQL to show the data now.