### PR TITLE
Abstract apollo client out of pages

### DIFF
--- a/pages/events.js
+++ b/pages/events.js
@@ -1,12 +1,9 @@
 import 'isomorphic-unfetch'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
+import { client } from '../services/graphql.js'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 function Events() {
   const { loading, error, data } = useQuery(gql`

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,15 +1,12 @@
 import 'isomorphic-unfetch'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Layout from '../components/Layout'
 import Map from '../components/Map'
 import Navigation from '../components/Navigation'
 import Footer from '../components/Footer'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 function Event() {
   const { loading, error, data } = useQuery(gql`

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,13 +1,10 @@
 import React from 'react'
 import 'isomorphic-unfetch'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 const Profile = () => {
   const { loading, error, data } = useQuery(gql`

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,13 +1,10 @@
 import 'isomorphic-unfetch'
 import React, { useState, useEffect } from 'react'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 const SEARCHEVENTS = gql`
   query SearchEvents($query: String!) {

--- a/pages/speaker.js
+++ b/pages/speaker.js
@@ -1,13 +1,10 @@
 import 'isomorphic-unfetch'
 import Head from 'next/head'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 function getParams() {
   return new URLSearchParams(

--- a/pages/speakers.js
+++ b/pages/speakers.js
@@ -1,13 +1,10 @@
 import 'isomorphic-unfetch'
 import Head from 'next/head'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 function Speakers() {
   const { loading, error, data } = useQuery(gql`

--- a/pages/videos.js
+++ b/pages/videos.js
@@ -1,13 +1,10 @@
 import React from 'react'
 import 'isomorphic-unfetch'
-import ApolloClient, { gql } from 'apollo-boost'
+import { gql } from 'apollo-boost'
+import { client } from '../services/graphql.js'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { useQuery } from '@apollo/react-hooks'
 import Page from '../components/Page'
-
-const client = new ApolloClient({
-  uri: 'https://graphql.copenhagenjs.dk/graphql'
-})
 
 const Embed = ({ youtubeId }) => {
   return (

--- a/services/graphql.js
+++ b/services/graphql.js
@@ -1,0 +1,7 @@
+import ApolloClient from 'apollo-boost'
+
+const client = new ApolloClient({
+  uri: 'https://graphql.copenhagenjs.dk/graphql'
+})
+
+export { client }


### PR DESCRIPTION
So many pages uses graphql now it made sense to refactor to a single instance 😄

Is related to https://github.com/copenhagenjs/copenhagenjs.dk/issues/194