### PR TITLE
Use bazel to tag and push to GCR and deploy

### DIFF
--- a/runs/graphql/BUILD
+++ b/runs/graphql/BUILD
@@ -26,3 +26,19 @@ sh_test(
   srcs = ["test.sh"],
   data = [":docker"],
 )
+
+genrule(
+  name = "tag",
+  srcs = ["build.txt"],
+  cmd = "docker tag $$(cat $(location build.txt)) gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$$SHA > $@",
+  outs = ["tag.txt"],
+  tags = ["manual"]
+)
+
+genrule(
+  name = "push",
+  srcs = ["tag.txt"],
+  cmd = "docker push gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$$SHA > $@",
+  outs = ["push_sha.txt"],
+  tags = ["manual"]
+)

--- a/runs/graphql/README.md
+++ b/runs/graphql/README.md
@@ -7,3 +7,9 @@ This is so we can easily pull data into the website
 ```
 $ bazel run //runs/graphql:run
 ```
+
+## How to push to GCR
+
+```
+$ bazel build //runs/graphql:push --action_env=SHA=$(git rev-parse --short=8 --verify HEAD) --sandbox_debug
+```

--- a/runs/graphql/cloudbuild.yaml
+++ b/runs/graphql/cloudbuild.yaml
@@ -8,4 +8,6 @@ steps:
     args:
       - "-c"
       - |
-        bazel build //runs/graphql:push --action_env=SHA=$SHORT_SHA --sandbox_debug
+        bazel build //runs/graphql:tag --action_env=SHA=$SHORT_SHA
+  - name: gcr.io/cloud-builders/docker
+    args: ["push", "gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$SHORT_SHA"]

--- a/runs/graphql/cloudbuild.yaml
+++ b/runs/graphql/cloudbuild.yaml
@@ -11,3 +11,11 @@ steps:
         bazel build //runs/graphql:tag --action_env=SHA=$SHORT_SHA
   - name: gcr.io/cloud-builders/docker
     args: ["push", "gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$SHORT_SHA"]
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        cd runs/graphql
+        sed -e "s/##IMAGE##/gcr.io\/copenhagenjsdk\/copenhagenjs.dk-graphql:$SHORT_SHA/" knative.yaml > knative_out.yaml
+        [[ "$BRANCH_NAME" == "master" ]] && gcloud alpha run services replace knative_out.yaml --platform=managed --region=europe-west1 || echo "Skipping ..."

--- a/runs/graphql/cloudbuild.yaml
+++ b/runs/graphql/cloudbuild.yaml
@@ -3,11 +3,9 @@ steps:
     args: ["build", "//runs/graphql:docker"]
   - name: gcr.io/cloud-builders/bazel
     args: ["test", "//runs/graphql:test"]
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/cloud-builders/bazel
     entrypoint: "bash"
     args:
       - "-c"
       - |
-        docker tag $(cat bazel-bin/runs/graphql/build.txt) gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$SHORT_SHA
-  - name: gcr.io/cloud-builders/docker
-    args: ["push", "gcr.io/copenhagenjsdk/copenhagenjs.dk-graphql:$SHORT_SHA"]
+        bazel build //runs/graphql:push --action_env=SHA=$SHORT_SHA --sandbox_debug

--- a/runs/graphql/knative.yaml
+++ b/runs/graphql/knative.yaml
@@ -1,0 +1,36 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: copenhagenjsdk-graphql
+  namespace: "173624392733"
+  labels:
+    cloud.googleapis.com/location: europe-west1
+  annotations:
+    run.googleapis.com/client-name: cloud-console
+    serving.knative.dev/creator: kevin.simper@gmail.com
+    serving.knative.dev/lastModifier: kevin.simper@gmail.com
+spec:
+  traffic:
+    - percent: 100
+      latestRevision: true
+  template:
+    metadata:
+      labels:
+        client.knative.dev/nonce: f6388aa8-955f-46b3-8ca4-7e600115b3e2
+      annotations:
+        autoscaling.knative.dev/maxScale: "1000"
+    spec:
+      timeoutSeconds: 300
+      serviceAccountName: 173624392733-compute@developer.gserviceaccount.com
+      containerConcurrency: 80
+      containers:
+        - image: ##IMAGE##
+          env:
+            - name: FOO
+              value: berglas://copenhagenjsdksecrets/foo
+            - name: FIREBASE_SVC_ACC
+              value: berglas://copenhagenjsdksecrets/firebase-svc-acc
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 1000m


### PR DESCRIPTION
I wrote about how to pass vars to bazel here https://www.kevinsimper.dk/posts/how-to-bazel-pass-environment-variables

Doing a docker push inside the bazel image was a bit complicated as it was not authenticated with gcloud. I will maybe try to do it later on Cloud Build, but it works locally if you are authenticated.