### PR TITLE
Add a better speakerprofile type

### DIFF
--- a/runs/graphql/src/events.js
+++ b/runs/graphql/src/events.js
@@ -2,10 +2,10 @@ const fm = require("front-matter");
 const marked = require("marked");
 const { readFileSync } = require("fs");
 const pMemoize = require("p-memoize");
-const data = require("../_posts/_data.json");
 const { join } = require("path");
 
 const getEvents = () => {
+  const data = require("../_posts/_data.json");
   return data.posts.map(post => {
     const markdown = readFileSync(join(__dirname, "../_posts/" + post), "utf8");
     const parsed = fm(markdown);

--- a/runs/graphql/src/resolvers/speakerprofile.js
+++ b/runs/graphql/src/resolvers/speakerprofile.js
@@ -1,0 +1,13 @@
+import { getSpeakers } from "../speakers.js";
+import { slugify } from "../slug.js";
+
+export const speakerProfile = (parent, { slug }) => {
+  const parsedPresentations = getSpeakers().filter(s =>
+    s.slug.toLowerCase().includes(slug.toLowerCase())
+  );
+  return {
+    name: parsedPresentations[0].name,
+    presentations: parsedPresentations.map(i => i.title),
+    slug: slugify(parsedPresentations[0].name)
+  };
+};

--- a/runs/graphql/src/resolvers/speakerprofile.test.js
+++ b/runs/graphql/src/resolvers/speakerprofile.test.js
@@ -1,0 +1,33 @@
+import { getSpeakers } from "../speakers.js";
+import { speakerProfile } from "./speakerprofile.js";
+import { slugify } from "../slug.js";
+jest.mock("../speakers.js");
+
+test("speakerProfile should be defined", () => {
+  expect(speakerProfile).toBeDefined();
+});
+
+test("speakerProfile should return a speaker", () => {
+  getSpeakers.mockReturnValue(
+    [
+      {
+        name: "Donald Duck",
+        title: "My first presentations"
+      },
+      {
+        name: "Donald Duck",
+        title: "Second presentation"
+      }
+    ].map(i => ({ ...i, slug: slugify(i.name) }))
+  );
+  const result = {
+    name: "Donald Duck",
+    slug: "donald-duck",
+    presentations: ["My first presentations", "Second presentation"]
+  };
+  const args = {
+    slug: result.slug
+  };
+  const speaker = speakerProfile({}, args);
+  expect(speaker).toEqual(result);
+});

--- a/runs/graphql/src/schema.js
+++ b/runs/graphql/src/schema.js
@@ -12,6 +12,7 @@ const {
   searchSpeakers,
   speaker
 } = require("./resolvers/speakers.js");
+const { speakerProfile } = require("./resolvers/speakerprofile.js");
 
 const typeDefs = gql`
   type Video {
@@ -39,10 +40,15 @@ const typeDefs = gql`
     location: String
     presentations: [Presentation]
   }
-  type Speaker {
-    title: String
+  type SpeakerProfile {
     name: String
     slug: String
+    presentations: [String]
+  }
+  type Speaker {
+    name: String
+    slug: String
+    title: String
     event: Event
   }
   type User {
@@ -71,6 +77,7 @@ const typeDefs = gql`
     searchEvents(query: String): [Event]
     speakers: [Speaker]
     speaker(slug: String!): [Speaker]
+    speakerProfile(slug: String!): SpeakerProfile
     searchSpeakers(name: String!): [Speaker]
     me: User
   }
@@ -89,6 +96,7 @@ const resolvers = {
     speakers,
     searchSpeakers,
     speaker,
+    speakerProfile,
     me
   },
   Speaker: {


### PR DESCRIPTION
The old type "Speaker" is not great. It was simple when starting out, as it nests the name inside an array of presentations.

This new type structure it better and does not duplicate the data to the client.

As we depend on it, this should be deployed and the places where speaker is used should be migrated.

