### PR TITLE
Move to new SpeakerProfile type

### DIFF
--- a/pages/speaker.js
+++ b/pages/speaker.js
@@ -24,26 +24,14 @@ export const SpeakerProfile = ({ name, presentations = [] }) => (
     <table>
       <thead>
         <tr>
-          <th>Date</th>
           <th>Title</th>
         </tr>
       </thead>
       <tbody>
-        {presentations.reverse().map(speaker => {
-          const date = new Date(parseInt(speaker.event.date))
+        {presentations.reverse().map(title => {
           return (
-            <tr key={speaker.title}>
-              <td>
-                {date
-                  .getDate()
-                  .toString()
-                  .padStart(2, '0')}
-                /{(date.getMonth() + 1).toString().padStart(2, '0')}/
-                {date.getFullYear()}
-              </td>
-              <td>
-                <a href={speaker.event.selfLink}>{speaker.title}</a>
-              </td>
+            <tr key={title}>
+              <td>{title}</td>
             </tr>
           )
         })}
@@ -56,28 +44,23 @@ function Speakers() {
   const slug = getParams().get('name')
   const { loading, error, data } = useQuery(gql`
     {
-      speaker(slug: "${slug}") {
+      speakerProfile(slug: "${slug}") {
         name
-        title
-        event {
-          selfLink
-          date
-        }
+        presentations
       }
     }
   `)
 
   if (loading) return <span>Loading...</span>
   if (error) return <span>Error :(</span>
-  if (data.speaker.length === 0) return <span>Could not find speaker</span>
   return (
     <div>
       <Head>
-        <title>{data.speaker[0].name} spoke at CopenhagenJS</title>
+        <title>{data.speakerProfile.name} spoke at CopenhagenJS</title>
       </Head>
       <SpeakerProfile
-        name={data.speaker[0].name}
-        presentations={data.speaker}
+        name={data.speakerProfile.name}
+        presentations={data.speakerProfile.presentations}
       />
     </div>
   )


### PR DESCRIPTION
Had to simplify it a bit, but it now uses the new type.

I can now make a new PR that add the Event to the presentation type without worrying that I am breaking the old Speaker type.

![image](https://user-images.githubusercontent.com/1126497/68066255-a5e73d80-fd35-11e9-89a8-81125f99745b.png)
