### PR TITLE
Make sure speaker website always links to external ressource

### DIFF
--- a/web/components/SpeakerProfile.js
+++ b/web/components/SpeakerProfile.js
@@ -90,7 +90,7 @@ export const SpeakerProfile = ({
           )}
           {user && user.website && (
             <li>
-              <a href={user.website}>Website</a>
+              <a href={user.website.startsWith('http') ? user.website : `https://${user.website}`}>Website</a>
             </li>
           )}
         </ul>


### PR DESCRIPTION
If it doesn't start with `http`, prefix the https protocol to make sure it links to an external ressource.