### PR TITLE
Remove html tags from excerpt on frontpage

### DIFF
--- a/web/components/Events.js
+++ b/web/components/Events.js
@@ -21,7 +21,13 @@ export const Events = {
             <div>
               {new Date(parseInt(event.date)).toDateString()} - {event.location}
             </div>
-            <div>{event.content.replace(/#/gm, '').slice(0, 200)} ...</div>
+            <div>
+              {event.content
+                .replace(/#/gm, '')
+                .replace(/(<([^>]+)>)/gi, '')
+                .slice(0, 200)}{' '}
+              ...
+            </div>
             <Link href={event.selfLink} size="small">
               Read more
             </Link>


### PR DESCRIPTION
Right now there is markdown html tags in the excerpt. This makes it readable.

> `<h1 id="copenhagenjs-february---dfds">CopenhagenJS February - DFDS</h1> <p>Hi everyone!</p> <p>First CopenhagenJS of the year and this time we are going to be at DFDS.</p> <p>A new year of JavaScript ...`

> `CopenhagenJS December - Dwarf.dk Hi everyone 😄 Last CopenhagenJS meetup of the year and even last CopenhagenJS meetup of this decade. Let us look back on this year and celebrate the good presentation ...`